### PR TITLE
@HostListener causes Bad Injection Token error

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -75,7 +75,7 @@ function extendWithHostListeners(ctrl: {new(...args: any[])}, listeners: IHostLi
       });
     }
   }
-  NewCtrl.$inject = ['$element', ...ctrl.$inject];
+  NewCtrl.$inject = ['$element', ...ctrl.$inject || []];
   return NewCtrl;
 }
 

--- a/test/ng-module.spec.ts
+++ b/test/ng-module.spec.ts
@@ -71,6 +71,10 @@ describe('NgModule', () => {
           ]);
           const invokeQueue = angular.module(moduleName)['_invokeQueue'];
           const ctrlProto = invokeQueue[0][2][1].controller.prototype;
+          const inject = ctrlProto['constructor']['$inject'];
+
+          inject.forEach(dependency => expect(typeof dependency).toBe('string'));
+          expect(inject[0]).toEqual('$element');
           expect(ctrlProto['constructor']['$inject'][0]).toEqual('$element');
           expect(ctrlProto['$postLink']).toBeDefined();
           expect(ctrlProto['$onDestroy']).toBeDefined();

--- a/test/ng-module.spec.ts
+++ b/test/ng-module.spec.ts
@@ -75,7 +75,6 @@ describe('NgModule', () => {
 
           inject.forEach(dependency => expect(typeof dependency).toBe('string'));
           expect(inject[0]).toEqual('$element');
-          expect(ctrlProto['constructor']['$inject'][0]).toEqual('$element');
           expect(ctrlProto['$postLink']).toBeDefined();
           expect(ctrlProto['$onDestroy']).toBeDefined();
         });


### PR DESCRIPTION
When @HostListener is used for a component having no dependencies to inject, you see https://docs.angularjs.org/error/$injector/itkn error and the component does not work. 
It happens due to this line:

```
NewCtrl.$inject = ['$element', ...ctrl.$inject];
```
Here `ctrl.$inject` might be `undefined` thus resulting in `NewCtrl.$inject` being equal to`['$element', undefined]` which leads to the DI error.

This PR fixes the issue.