### PR TITLE
Fix lifecycle hook mapping

### DIFF
--- a/src/lifecycle_hooks.ts
+++ b/src/lifecycle_hooks.ts
@@ -1,24 +1,13 @@
 /**
  * @internal
- */
-export enum LifecycleHooks {
-  OnInit,
-  OnDestroy,
-  DoCheck,
-  OnChanges,
-  AfterViewInit
-}
-
-/**
- * @internal
  * @desc Mapping between angular and angularjs LifecycleHooks
  */
-export const ngLifecycleHooksMap = {
-  [LifecycleHooks.OnInit]: '$onInit',
-  [LifecycleHooks.OnDestroy]: '$onDestroy',
-  [LifecycleHooks.DoCheck]: '$doCheck',
-  [LifecycleHooks.OnChanges]: '$onChanges',
-  [LifecycleHooks.AfterViewInit]: '$postLink'
+export const ngLifecycleHooksMap: object = {
+  ngOnInit: '$onInit',
+  ngOnDestroy: '$onDestroy',
+  ngDoCheck: '$doCheck',
+  ngOnChanges: '$onChanges',
+  ngAfterViewInit: '$postLink'
 };
 
 /**


### PR DESCRIPTION
fix(@Component) Resolve #26 where lifecycle hooks are not mapped due to Object.keys() usage on the controller class.

Object.keys() only returns enumerable properties, which does not play nice with ES6 classes.
https://stackoverflow.com/questions/31423573/how-to-enumerate-es6-class-methods

Now test for each of the Angular hooks being defined as a function rather than iterating through the keys of the controller class prototype.