### PR TITLE
TypeScript 2.4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rollup": "^0.41.6",
     "standard-version": "^4.0.0",
     "tslint": "^5.1.0",
-    "typescript": "^2.3.2",
+    "typescript": "^2.4.0",
     "uglify-es": "^3.0.4"
   },
   "peerDependencies": {

--- a/src/module.ts
+++ b/src/module.ts
@@ -22,12 +22,7 @@ export interface NgModule {
   module?: ng.IModule;
   config?(...args: any[]): void;
   run?(...args: any[]): void;
-
-
-  // NgModule implementations frequently do not implement any of its methods
-  // and module is gets applied by the decorator at runtime.
-  // A string indexer indicates to TypeScript 2.4 not to issue a weak type error in this case.
-  [s: string]: any;
+  [p: string]: any;
 }
 
 export function NgModule({ id, name, declarations = [], imports = [], providers = [] }: ModuleConfig) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,6 +21,12 @@ export interface NgModule {
   module?: ng.IModule;
   config?(...args: any[]): void;
   run?(...args: any[]): void;
+
+
+  // NgModule implementations frequently do not implement any of its methods
+  // and module is gets applied by the decorator at runtime.
+  // A string indexer indicates to TypeScript 2.4 not to issue a weak type error in this case.
+  [s: string]: any;
 }
 
 export function NgModule({ id, name, declarations, imports = [], providers }: ModuleConfig) {


### PR DESCRIPTION
Fix(NgModule) Support for TypeScript 2.4, which requires a weak interface fix to the NgModule.

This follows the same method used by DefinitelyTyped. Fixes issue #23.