### PR TITLE
Fixed type for declarations

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -12,7 +12,7 @@ export interface ModuleConfig {
    * @deprecated
    */
   name?: string;
-  declarations?: Array<ng.IComponentController | ng.Injectable<ng.IDirectiveFactory> | PipeTransform>;
+  declarations?: Function[];
   imports?: Array<string | NgModule>;
   exports?: Function[];
   providers?: Provider[];


### PR DESCRIPTION
Fixed error:
TS2345: (...) Type 'typeof XYZComponent' is not assignable to type 'IComponentController | IDirectiveFactory> | PipeTransform ..."

This error is displayed, even if XYZComponent implements ng.IComponentController