### PR TITLE
SimpleChange aligned to AngularJS + generic

### DIFF
--- a/src/lifecycle_hooks.ts
+++ b/src/lifecycle_hooks.ts
@@ -14,7 +14,7 @@ export const ngLifecycleHooksMap: object = {
  * Represents a basic change from a previous to a new value.
  * @stable
  */
-export declare class SimpleChange<T> {
+export declare class SimpleChange<T> implements ng.IChangesObject<T> {
   previousValue: T;
   currentValue: T;
   constructor(previousValue: T, currentValue: T);
@@ -30,7 +30,7 @@ export declare class SimpleChange<T> {
  * values are instances of {@link SimpleChange}. See {@link OnChanges}
  * @stable
  */
-export interface SimpleChanges { [propName: string]: SimpleChange<any>; }
+export interface SimpleChanges extends ng.IOnChangesObject { [propName: string]: SimpleChange<any>; }
 
 /**
  * @whatItDoes Lifecycle hook that is called when any data-bound property of a directive changes.

--- a/src/lifecycle_hooks.ts
+++ b/src/lifecycle_hooks.ts
@@ -14,13 +14,15 @@ export const ngLifecycleHooksMap: object = {
  * Represents a basic change from a previous to a new value.
  * @stable
  */
-export class SimpleChange {
-  constructor(public previousValue: any, public currentValue: any, public firstChange: boolean) {}
+export declare class SimpleChange<T> {
+  previousValue: T;
+  currentValue: T;
+  constructor(previousValue: T, currentValue: T);
 
   /**
    * Check whether the new value is the first value assigned.
    */
-  isFirstChange(): boolean { return this.firstChange; }
+  isFirstChange(): boolean;
 }
 
 /**
@@ -28,7 +30,7 @@ export class SimpleChange {
  * values are instances of {@link SimpleChange}. See {@link OnChanges}
  * @stable
  */
-export interface SimpleChanges { [propName: string]: SimpleChange; }
+export interface SimpleChanges { [propName: string]: SimpleChange<any>; }
 
 /**
  * @whatItDoes Lifecycle hook that is called when any data-bound property of a directive changes.


### PR DESCRIPTION
AngularJS 1.5 and 1.6 `SimpleChange` does not contain `firstChange` boolean.
SimpleChange constructor in dev-tools is given as:
```js
ƒ SimpleChange(previous, current) {
  this.previousValue = previous;
  this.currentValue = current;
}
```
while `isFirstChange()` is:
```js
ƒ () { return this.previousValue === _UNINITIALIZED_VALUE; }
```


[DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/angular/index.d.ts#L1960) defines this object using this interface, which is more in line with the class declaration:
```typescript
    interface IChangesObject<T> {
        currentValue: T;
        previousValue: T;
        isFirstChange(): boolean;
    }
```