### PR TITLE
remove console.warn from directive.ts

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -26,13 +26,7 @@ export function Directive({selector, ...options}: DirectiveOptionsDecorated) {
       options.bindToController = bindings;
     }
     options.restrict = options.restrict || 'A';
-    if (options.restrict !== 'A') {
-      console.warn(`Consider removing restrict option from ${selector} directive and using it only as
-       attribute directive.`);
-    }
-    if (options.link || options.compile) {
-      console.warn(`Consider refactoring ${selector} directive using controller class.`);
-    }
+
     const selectorName = isAttributeSelector(selector) ? getAttributeName(selector) : selector;
     defineMetadata(metadataKeys.name, kebabToCamel(selectorName), ctrl);
     defineMetadata(metadataKeys.declaration, Declarations.directive, ctrl);


### PR DESCRIPTION
We are migrating legacy angularjs projects to typescript using angular-ts-decorators. In some cases we cannot change old logic and do deep refactoring. Somewhere we need @Directive with restrict='E' and with link function. Because of that we have very annoying warnings.

WARN: 'Consider refactoring someDirective directive using controller class.'
WARN: 'Consider removing restrict option from someDirective directive and using it only as
       attribute directive.'
