### PR TITLE
Allow filters/pipes to declare self as stateful

### DIFF
--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -7,7 +7,7 @@ export interface PipeTransform {
   transform(...args: any[]): any;
 }
 
-export function Pipe(options: {name: string}) {
+export function Pipe(options: {name: string, stateful: boolean}) {
   return (Class: PipeTransformConstructor) => {
     defineMetadata(metadataKeys.name, options.name, Class);
     defineMetadata(metadataKeys.declaration, Declarations.pipe, Class);

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -7,7 +7,7 @@ export interface PipeTransform {
   transform(...args: any[]): any;
 }
 
-export function Pipe(options: {name: string, stateful: boolean}) {
+export function Pipe(options: {name: string, stateful?: boolean}) {
   return (Class: PipeTransformConstructor) => {
     defineMetadata(metadataKeys.name, options.name, Class);
     defineMetadata(metadataKeys.declaration, Declarations.pipe, Class);

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -11,16 +11,22 @@ export function Pipe(options: {name: string}) {
   return (Class: PipeTransformConstructor) => {
     defineMetadata(metadataKeys.name, options.name, Class);
     defineMetadata(metadataKeys.declaration, Declarations.pipe, Class);
+    defineMetadata(metadataKeys.options, options, Class);
   };
 }
 
 /** @internal */
 export function registerPipe(module: ng.IModule, filter: PipeTransformConstructor) {
   const name = getMetadata(metadataKeys.name, filter);
+  const options = getMetadata(metadataKeys.options, filter);
   const filterFactory = (...args: any[]) => {
     const injector = args[0]; // reference to $injector
     const instance = injector.instantiate(filter);
-    return instance.transform.bind(instance);
+    const transform = instance.transform.bind(instance);
+    if (options.stateful) {
+      transform.$stateful = options.stateful;
+    }
+    return transform;
   };
   filterFactory.$inject = ['$injector', ...(filter.$inject || annotate(filter))];
   module.filter(name, filterFactory);


### PR DESCRIPTION
This is to support legacy, albiet bad practice but sometimes needed stateful filters. Example of such a scenario is a translation pipes.