### PR TITLE
fix(directive): bindToController with require in case of empty bindings

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -24,6 +24,7 @@ export function Directive({selector, ...options}: DirectiveOptionsDecorated) {
     const require = getMetadata(metadataKeys.require, ctrl);
     if (require) {
       options.require = require;
+      if (!options.bindToController) options.bindToController = true;
     }
     options.restrict = options.restrict || 'A';
 


### PR DESCRIPTION
If @Directive doesn't have any bindings, and it have a @ViewParent() require, this won't work without 'bindToController' option.

So, this won't work. `this.ngModel` is always empty.

`
    import { Directive, ViewParent, OnInit } from 'angular-ts-decorators';
    import * as ng from 'angular';

    @Directive({
        selector: '[no-dirty]'
    })
    export class NoDirty implements OnInit {
        @ViewParent('^ngModel') ngModel: ng.INgModelController;
        ngOnInit () {
            if (this.ngModel) this.ngModel.$setDirty = ng.noop;
        }
    }
`