### PR TITLE
Directives class name selectors

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -1,6 +1,6 @@
 import {
   Declaration, defineMetadata, getAttributeName, getMetadata, isAttributeSelector, kebabToCamel,
-  metadataKeys
+  metadataKeys, tryGetDirectiveSelector
 } from './utils';
 import { IHostListeners } from './hostListener';
 import { IViewChildren } from './viewChild';
@@ -26,9 +26,10 @@ export function Directive({selector, ...options}: DirectiveOptionsDecorated) {
       options.require = require;
       if (!options.bindToController) options.bindToController = true;
     }
-    options.restrict = options.restrict || 'A';
 
-    const selectorName = isAttributeSelector(selector) ? getAttributeName(selector) : selector;
+    const selectorTyped = tryGetDirectiveSelector(selector);
+    const selectorName = selectorTyped.selector || selector;
+    options.restrict = options.restrict || selectorTyped.restrict || 'A';
     defineMetadata(metadataKeys.name, kebabToCamel(selectorName), ctrl);
     defineMetadata(metadataKeys.declaration, Declaration.Directive, ctrl);
     defineMetadata(metadataKeys.options, options, ctrl);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,15 @@ import 'reflect-metadata';
 
 export enum Declaration { Component = 'Component', Directive = 'Directive', Pipe = 'Pipe' }
 
+export type DirectiveRestriction = 'A' | 'E' | 'C';
+
+/** @internal */
+export const knownDirectiveTypes: Record<DirectiveRestriction, RegExp> = {
+  A: /^\[([a-z][a-zA-Z\-_]*?)\]$/,
+  E: /^([a-z\-]*)$/,
+  C: /^\.([a-z][a-zA-Z\-_]*?)$/
+};
+
 /** @internal */
 export const metadataKeys = {
   declaration: 'custom:declaration',
@@ -29,6 +38,15 @@ export function getAttributeName(selector: string) {
 /** @internal */
 export function isAttributeSelector(selector: string) {
   return /^[\[].*[\]]$/g.test(selector);
+}
+
+/** @internal */
+export function tryGetDirectiveSelector(selector: string): Partial<{ selector: string, restrict: DirectiveRestriction }> {
+  for (const restrictBy of Object.keys(knownDirectiveTypes)) {
+    const match = selector.match(knownDirectiveTypes[restrictBy]);
+    if (match && match[1]) return { selector: match[1], restrict: restrictBy as DirectiveRestriction };
+  }
+  return {};
 }
 
 /** @internal */

--- a/test/ng-module.spec.ts
+++ b/test/ng-module.spec.ts
@@ -116,9 +116,10 @@ describe('NgModule', () => {
           directive('camel-case-name'),
           directive('[camelCaseName]'),
           directive('[camel-case-name]'),
+          directive('.camel-case-name'),
         ]);
         const invokeQueue = angular.module(moduleName)['_invokeQueue'];
-        expect(invokeQueue.length).toEqual(4);
+        expect(invokeQueue.length).toEqual(5);
         invokeQueue.forEach((value: any) => {
           expect(value[0]).toEqual('$compileProvider');
           expect(value[1]).toEqual('directive');


### PR DESCRIPTION
Here is another 50 cents from me. :)
[Angular Directive](https://angular.io/api/core/Directive)

> Declare as one of the following:
> 
> element-name: Select by element name.
> .class: Select by class name.
> [attribute]: Select by attribute name.

I edited directive declaration, so it'll try to parse different types of selectors a bit stricter.
So in case of `element-name` we'll restrict directive to `E`, in case of `.class` - to `C`, and in case of `[attribute]` - to `A`.

And I just wanted to add that your library is truly awesome!