### PR TITLE
Problem with bindings of child classes being set on the parent class resulting in polluted bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "test": "karma start --single-run",
     "test:dev": "karma start",
     "posttest": "cat ./coverage/lcov.info | coveralls",
-    "prepare": "npm run build",
     "build": "npm run clean && tsc && rollup -c && npm run uglify && copyfiles package.json README.md CHANGELOG.md LICENSE dist/ && rimraf dist/temp",
     "uglify": "for f in dist/*.js; do ./node_modules/uglify-es/bin/uglifyjs $f --compress drop_console --mangle --output ${f%.js}.min.js; done",
     "release": "standard-version",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test": "karma start --single-run",
     "test:dev": "karma start",
     "posttest": "cat ./coverage/lcov.info | coveralls",
+    "prepare": "npm run build",
     "build": "npm run clean && tsc && rollup -c && npm run uglify && copyfiles package.json README.md CHANGELOG.md LICENSE dist/ && rimraf dist/temp",
     "uglify": "for f in dist/*.js; do ./node_modules/uglify-es/bin/uglifyjs $f --compress drop_console --mangle --output ${f%.js}.min.js; done",
     "release": "standard-version",

--- a/src/hostListener.ts
+++ b/src/hostListener.ts
@@ -1,4 +1,5 @@
 import { defineMetadata, getMetadata, metadataKeys } from './utils';
+import * as angular from 'angular';
 
 /** @internal */
 export interface IHostListeners {
@@ -20,7 +21,7 @@ export function HostListener(eventName?: string, args?: string[]) {
     /**
      * listeners = { onMouseEnter: { eventName: 'mouseenter mouseover', args: [] } }
      */
-    const listeners: IHostListeners  = Object.assign({}, getMetadata(metadataKeys.listeners, targetConstructor) || {});
+    const listeners: IHostListeners  = angular.extend({}, getMetadata(metadataKeys.listeners, targetConstructor) || {});
     listeners[propertyKey] = { eventName, args };
     defineMetadata(metadataKeys.listeners, listeners, targetConstructor);
   };

--- a/src/hostListener.ts
+++ b/src/hostListener.ts
@@ -20,7 +20,7 @@ export function HostListener(eventName?: string, args?: string[]) {
     /**
      * listeners = { onMouseEnter: { eventName: 'mouseenter mouseover', args: [] } }
      */
-    const listeners: IHostListeners = getMetadata(metadataKeys.listeners, targetConstructor) || {};
+    const listeners: IHostListeners  = Object.assign({}, getMetadata(metadataKeys.listeners, targetConstructor) || {});
     listeners[propertyKey] = { eventName, args };
     defineMetadata(metadataKeys.listeners, listeners, targetConstructor);
   };

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,4 +1,5 @@
 import { defineMetadata, getMetadata, metadataKeys } from './utils';
+import * as angular from 'angular';
 
 export function Input(alias?: string) {
   return (target: any, key: string) => addBindingToMetadata(target, key, '<?', alias);
@@ -15,7 +16,7 @@ export function ViewParent(controller: string) {
 /** @internal */
 function addBindingToMetadata(target: any, key: string, direction: string, alias?: string) {
   const targetConstructor = target.constructor;
-  const bindings = Object.assign({}, getMetadata(metadataKeys.bindings, targetConstructor) || {});
+  const bindings = angular.extend({}, getMetadata(metadataKeys.bindings, targetConstructor) || {});
   bindings[key] = alias || direction;
   defineMetadata(metadataKeys.bindings, bindings, targetConstructor);
 }
@@ -23,7 +24,7 @@ function addBindingToMetadata(target: any, key: string, direction: string, alias
 /** @internal */
 function addRequireToMetadata(target: any, key: string, controller: string) {
   const targetConstructor = target.constructor;
-  const require = Object.assign({}, getMetadata(metadataKeys.require, targetConstructor) || {});
+  const require = angular.extend({}, getMetadata(metadataKeys.require, targetConstructor) || {});
   require[key] = controller;
   defineMetadata(metadataKeys.require, require, targetConstructor);
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -15,7 +15,7 @@ export function ViewParent(controller: string) {
 /** @internal */
 function addBindingToMetadata(target: any, key: string, direction: string, alias?: string) {
   const targetConstructor = target.constructor;
-  const bindings = getMetadata(metadataKeys.bindings, targetConstructor) || {};
+  const bindings = Object.assign({}, getMetadata(metadataKeys.bindings, targetConstructor) || {});
   bindings[key] = alias || direction;
   defineMetadata(metadataKeys.bindings, bindings, targetConstructor);
 }
@@ -23,7 +23,7 @@ function addBindingToMetadata(target: any, key: string, direction: string, alias
 /** @internal */
 function addRequireToMetadata(target: any, key: string, controller: string) {
   const targetConstructor = target.constructor;
-  const require = getMetadata(metadataKeys.require, targetConstructor) || {};
+  const require = Object.assign({}, getMetadata(metadataKeys.require, targetConstructor) || {});
   require[key] = controller;
   defineMetadata(metadataKeys.require, require, targetConstructor);
 }

--- a/src/viewChild.ts
+++ b/src/viewChild.ts
@@ -1,6 +1,7 @@
 import { ElementRef } from './element_ref';
 import { defineMetadata, getMetadata, metadataKeys } from './utils';
 import { Type } from './type';
+import * as angular from 'angular';
 
 /** @internal */
 export interface IViewChildren {
@@ -26,7 +27,7 @@ function addBindingToMetadata(target: any,
                               read: typeof ElementRef,
                               first: boolean) {
   const targetConstructor = target.constructor;
-  const viewChildren: IViewChildren = Object.assign({},
+  const viewChildren: IViewChildren = angular.extend({},
     getMetadata(metadataKeys.viewChildren, targetConstructor) || {});
   viewChildren[key] = { first, selector, read };
   defineMetadata(metadataKeys.viewChildren, viewChildren, targetConstructor);

--- a/src/viewChild.ts
+++ b/src/viewChild.ts
@@ -26,7 +26,8 @@ function addBindingToMetadata(target: any,
                               read: typeof ElementRef,
                               first: boolean) {
   const targetConstructor = target.constructor;
-  const viewChildren: IViewChildren = getMetadata(metadataKeys.viewChildren, targetConstructor) || {};
+  const viewChildren: IViewChildren = Object.assign({},
+    getMetadata(metadataKeys.viewChildren, targetConstructor) || {});
   viewChildren[key] = { first, selector, read };
   defineMetadata(metadataKeys.viewChildren, viewChildren, targetConstructor);
 }


### PR DESCRIPTION
We have been using this for 3 months now, and like it so far - it is our intermediate step to go from ng1.5 to ng7.
We have create a base class with @Input and many child classes off that and each child class has its own @Input.
We started to see the instance of the child class contained many extra properties that are not part it.
I traced the code to what I have updated in my pull request:
The Reflection returns object back and it gets the meta of the child class's parent first, and it will find the parent class' binding object and returning that. And in ts-decorator it add a binding to the object returned (parent's object) and store back to itself. Since object is by reference, this mean the child and parent is sharing the same object. So my change is to clone the object returned (shallow) and add new binding to that and store the new object back.

I tested locally with our code and that solve the issues we were seeing.

I went ahead and update any of the decorators that is placed inside of a class. Please review it and see if it is ok.

Btw, I tried to build it with npm run install, but no luck. Not sure how you build it :)

Jonathan