### PR TITLE
Fix(ViewChild): Call updateViewChildren before AfterViewInit accordin…

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -108,6 +108,7 @@ export function extendWithHostListenersAndChildren(ctrl: {new(...args: any[])},
       });
     }
     $postLink() {
+      this._updateViewChildren();
       if (super.$postLink) {
         super.$postLink();
       }
@@ -115,13 +116,12 @@ export function extendWithHostListenersAndChildren(ctrl: {new(...args: any[])},
         const { eventName } = listeners[handler];
         this.$element.on(eventName + namespace, this[handler].bind(this));
       });
-      this._updateViewChildren();
     }
     $onChanges(changes) {
+      this._updateViewChildren();
       if (super.$onChanges) {
         super.$onChanges(changes);
       }
-      this._updateViewChildren();
     }
     $onDestroy() {
       if (super.$onDestroy) {


### PR DESCRIPTION
…g to Angular specs

According tot the [Angular specs](https://angular.io/api/core/ViewChildren) `ViewChildren` should be set *before* calling `AfterViewInit`.

```
View queries are set before the ngAfterViewInit callback is called.
```

Now you have to wrap your code in a `setTimeout` in order to use the `ViewChildren` in `AfterViewInit`