### PR TITLE
Fix for useFactory providers

### DIFF
--- a/src/injectable.ts
+++ b/src/injectable.ts
@@ -32,11 +32,14 @@ export function registerProviders(module: IModule, providers: Provider[]) {
     // providers registered using { provide, useClass/useFactory/useValue } syntax
     if (provider.provide) {
       const name = provider.provide;
-      if (provider.useClass && provider.useClass instanceof Function) {
+      if (provider.useClass) {
         module.service(name, provider.useClass);
       }
-      else if (provider.useFactory && provider.useFactory instanceof Function) {
-        provider.useFactory.$inject = provider.deps || provider.useFactory.$inject;
+      else if (provider.useFactory) {
+        if (provider.deps) {
+          provider.useFactory = replaceDependencies(provider.useFactory, provider.deps);
+        }
+
         module.factory(name, provider.useFactory);
       }
       else if (provider.useValue) {
@@ -55,4 +58,14 @@ export function registerProviders(module: IModule, providers: Provider[]) {
       }
     }
   });
+}
+
+
+function replaceDependencies(injectableFunction: any, deps: any[]) {
+  if (Array.isArray(injectableFunction)) {
+    injectableFunction = injectableFunction[injectableFunction.length - 1];
+  }
+
+  injectableFunction.$inject = deps;
+  return injectableFunction;
 }

--- a/test/ng-module.spec.ts
+++ b/test/ng-module.spec.ts
@@ -224,6 +224,39 @@ describe('NgModule', () => {
           expect(value[2][1]).toBe(providers[index].useFactory);
         });
       });
+      it('registers provider with factory function annotated with array syntax', () => {
+        const providers = [
+          {provide: 'useFactoryTestService', useFactory: ['foo', (foo) => new TestService(foo)] },
+          {provide: 'foo', useValue: 'bar'}
+        ];
+        registerNgModule(moduleName, [], [], providers);
+
+        const invokeQueue = angular.module(moduleName)['_invokeQueue'];
+        expect(invokeQueue.length).toEqual(providers.length);
+        const providerInvoke = invokeQueue[1];
+        expect(providerInvoke[0]).toEqual('$provide');
+        expect(providerInvoke[1]).toEqual('factory');
+        expect(providerInvoke[2][0]).toEqual(providers[0].provide);
+        expect(providerInvoke[2][1]).toBe(providers[0].useFactory);
+      });
+      it('registers provider with factory function annotated with $inject syntax', () => {
+        const useFactory = (foo) => new TestService(foo);
+        useFactory.$inject = ['foo'];
+
+        const providers = [
+          {provide: 'useFactoryTestService', useFactory },
+          {provide: 'foo', useValue: 'bar'}
+        ];
+        registerNgModule(moduleName, [], [], providers);
+
+        const invokeQueue = angular.module(moduleName)['_invokeQueue'];
+        expect(invokeQueue.length).toEqual(providers.length);
+        const providerInvoke = invokeQueue[1];
+        expect(providerInvoke[0]).toEqual('$provide');
+        expect(providerInvoke[1]).toEqual('factory');
+        expect(providerInvoke[2][0]).toEqual(providers[0].provide);
+        expect(providerInvoke[2][1]).toBe(providers[0].useFactory);
+      });
     });
 
     describe('useValue', () => {


### PR DESCRIPTION
If you declare a provider with a useFactory function, sometimes it was being ignored and not registered in the angular module.

It looks like this was related to the deps property not handling the array style dependency inject annotation.
for example:
```
@NgModule({
  providers: [{ provide: 'SomeService', useFactory: [
    'service1', 'service2',
    function(service1, service2) { ... }
  ]}]
 })
```

The existing code expects useFactory to be a function, but it may be an array instead.
